### PR TITLE
Add deprication notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+This project is no longer maintaned
+===================================
+
+**Alternatives?**
+
+- [Cassandra Medusa](https://github.com/thelastpickle/cassandra-medusa) is a great project maintained by The Last Pickle ltd subsidiry of DataStax. This tool supports both Amazon S3 and GCS.
+
 cassandra_snap
 ======================
 


### PR DESCRIPTION
_cassandra_snap_ is deprecated because of the lack of support from the
community. Add deprecation notice and suggest alternative
solution that has more support.